### PR TITLE
Add data for district and forest client tables via migrations

### DIFF
--- a/apps/api/src/app/modules/app-config/database.configuration.ts
+++ b/apps/api/src/app/modules/app-config/database.configuration.ts
@@ -2,7 +2,7 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('db', () => ({
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
-  synchronize: process.env.NODE_ENV !== 'production',
+  synchronize: false, // process.env.NODE_ENV !== 'production',
   type: process.env.DB_TYPE,
   database: process.env.DB,
   schema: 'app_fom',

--- a/migration/1616014739471-district.ts
+++ b/migration/1616014739471-district.ts
@@ -1,0 +1,41 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class district1616014739471 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        DELETE FROM app_fom.district;
+
+        INSERT INTO app_fom.district(district_id, name, create_user) VALUES 
+        (43, 'Campbell River Natural Resource District', CURRENT_USER),
+        (56, '100 Mile House Natural Resource District', CURRENT_USER),
+        (1826, 'Cariboo-Chilcotin Natural Resource District', CURRENT_USER),
+        (1828, 'Cascades Natural Resource District', CURRENT_USER),
+        (15, 'Chilliwack Natural Resource District', CURRENT_USER),
+        (32, 'Coast Mountains Natural Resource District', CURRENT_USER),
+        (46, 'Fort Nelson Natural Resource District', CURRENT_USER),
+        (48, 'Haida Gwaii Natural Resource District', CURRENT_USER),
+        (38, 'Mackenzie Natural Resource District', CURRENT_USER),
+        (1823, 'Nadina Natural Resource District', CURRENT_USER),
+        (1832, 'North Island - Central Coast Natural Resource District', CURRENT_USER),
+        (1829, 'Okanagan Shuswap Natural Resource District', CURRENT_USER),
+        (1825, 'Peace Natural Resource District', CURRENT_USER),
+        (18, 'Prince George Natural Resource District', CURRENT_USER),
+        (50, 'Quesnel Natural Resource District', CURRENT_USER),
+        (1831, 'Rocky Mountain Natural Resource District', CURRENT_USER),
+        (23, 'Sea to Sky Natural Resource District', CURRENT_USER),
+        (1902, 'Selkirk Natural Resource District', CURRENT_USER),
+        (1824, 'Skeena Stikine Natural Resource District', CURRENT_USER),
+        (1619, 'South Island Natural Resource District', CURRENT_USER),
+        (30, 'Stuart Nechako Natural Resource District', CURRENT_USER),
+        (27, 'Sunshine Coast Natural Resource District', CURRENT_USER),
+        (21, 'Thompson Rivers Natural Resource District', CURRENT_USER)
+        ;
+        
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/migration/1616015261635-forestClient.ts
+++ b/migration/1616015261635-forestClient.ts
@@ -1,0 +1,48 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class forestClient1616015261635 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        -- DELETE FROM app_fom.forest_client;
+
+        INSERT INTO app_fom.forest_client(forest_client_number, name, create_user) VALUES 
+        ('1011', 'AKIECA EXPLORERS LTD.', CURRENT_USER),
+        ('1012', 'BELL LUMBER & POLE CANADA, ULC', CURRENT_USER),
+        ('1016', 'ALBREDA RIVER POLE CO. LTD.', CURRENT_USER),
+        ('1021', 'ROYAL PACIFIC TRANSPORT LTD.', CURRENT_USER),
+        ('1026', 'ALLISON PASS SAWMILLS LTD.', CURRENT_USER),
+        ('1027', 'ALLISON LOGGING CO. LTD.', CURRENT_USER),
+        ('1035', 'CANADIAN OVERSEAS LOG & LUMBER LTD.', CURRENT_USER),
+        ('177031', 'DIVINE LOGISTICS LTD.', CURRENT_USER),
+        ('1056', 'APOLLO FOREST PRODUCTS LTD.', CURRENT_USER),
+        ('1060', 'ARROW LAKES CEDAR POLE', CURRENT_USER),
+        ('1062', 'FIRST TIER ENERGY LTD.', CURRENT_USER),
+        ('1065', 'ATCO LUMBER LTD.', CURRENT_USER),
+        ('1075', 'BRITISH COLUMBIA RAILWAY COMPANY', CURRENT_USER),
+        ('1081', 'W.E.BAIKIE LOGGING LTD.', CURRENT_USER),
+        ('1094', 'R. H. BARBOUR LOGGING CO. LTD.', CURRENT_USER),
+        ('1169', 'BOSER CEDAR PRODUCTS LTD.', CURRENT_USER),
+        ('1183', 'BOW RIVER RESOURCES LTD', CURRENT_USER),
+        ('1201', 'BRANHAM SHAKE CO. LTD.', CURRENT_USER),
+        ('1297', 'CARRIER LUMBER LTD.', CURRENT_USER),
+        ('1310', 'CATTERMOLE TIMBER LTD.', CURRENT_USER),
+        ('1311', 'CAWLEY SAWMILL LTD.', CURRENT_USER),
+        ('1314', 'CEDAR RIVER TIMBER (1971) CO. LTD.', CURRENT_USER),
+        ('1317', 'CEDEX TIMBER LTD.', CURRENT_USER),
+        ('1333', 'CHEVRON CANADA RESOURCES LIMITED', CURRENT_USER),
+        ('1338', 'CHILAKO SAWMILL LTD.', CURRENT_USER),
+        ('1341', 'H.S. CHRISTENSEN LOGGING LTD.', CURRENT_USER),
+        ('1379', 'COOKS CREEK SAWMILL LTD.', CURRENT_USER),
+        ('1386', 'COSEKA RESOURCES LIMITED', CURRENT_USER),
+        ('1418', 'CZAR RESOURCES LTD.', CURRENT_USER),
+        ('1427', 'WINDCHIME DEVELOPMENTS INC', CURRENT_USER),
+        ('1429', 'DARFIELD BUILDING PRODUCTS INC.', CURRENT_USER)
+        ;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
I only added a small subset of the ~20,000 forest clients, but the subset is real. The list of districts is complete.