### PR TITLE
Fix 'communicationDate' had one day difference

### DIFF
--- a/apps/api/src/app/modules/interaction/interaction.entity.ts
+++ b/apps/api/src/app/modules/interaction/interaction.entity.ts
@@ -13,7 +13,7 @@ export class Interaction extends ApiBaseEntity<Interaction> {
   @Column()
   stakeholder: string;
 
-  @Column({ name: 'communication_date'})
+  @Column({ name: 'communication_date', type: 'date'})
   communicationDate: string; // timestamp
 
   @Column({ name: 'communication_details'})


### PR DESCRIPTION
Fix 'communicationDate' had one day difference: because the property contains zero timezone 'time' string.