### PR TITLE
FOM-46: Fix Attachment Upload Widget display cut off

### DIFF
--- a/apps/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/apps/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -53,7 +53,12 @@ export class InteractionDetailComponent implements OnInit {
   
   addNewFile(newFiles: any[]) {
     this.files = newFiles;
-    this.interactionFormGroup.get('filename').setValue(newFiles[0].name);
+    if (!this.files || this.files.length == 0) {
+      this.interactionFormGroup.get('filename').setValue(null);
+    }
+    else {
+      this.interactionFormGroup.get('filename').setValue(newFiles[0].name);
+    }
   }
 
   getFileContent(fileContent: any) {

--- a/apps/admin/src/core/components/file-upload-box/file-upload-box.component.scss
+++ b/apps/admin/src/core/components/file-upload-box/file-upload-box.component.scss
@@ -30,7 +30,6 @@
 
      .upload-control {
          //z-index: 2 !important;
-       height: 100px;
          ngx-dropzone {
            height: 100px;
              z-index: 3 !important;

--- a/apps/admin/src/core/components/file-upload-box/file-upload-box.component.scss
+++ b/apps/admin/src/core/components/file-upload-box/file-upload-box.component.scss
@@ -39,6 +39,12 @@
                  text-decoration: underline;
                  cursor: pointer;
              }
+
+             ngx-dropzone-preview, ngx-dropzone-image-preview {
+                 height: 90px !important;
+                 max-height: 100px !important;
+                 min-height: 50px !important;
+             }
          }
      }
  }

--- a/apps/admin/src/core/components/file-upload-box/file-upload-box.component.ts
+++ b/apps/admin/src/core/components/file-upload-box/file-upload-box.component.ts
@@ -129,8 +129,9 @@ export class UploadBoxComponent implements OnInit {
 
     if (this.files.length > 1 && !this.multipleFiles){
       this.invalidTypeText = 'Only one document is allowed';
-      this.onRemove(event);
+      this.onRemove(event.addedFiles[0]);
     }
+
     if (event.addedFiles.length > 0 ) {
       if( this.isBlob){
         this.readFileContentAsBlob(this.files[0])
@@ -162,6 +163,9 @@ export class UploadBoxComponent implements OnInit {
 
   onRemove(event) {
     this.files.splice(this.files.indexOf(event), 1);
+    if (this.files.length == 0) {
+      this.invalidTypeText = null;
+    }
     this.fileUploaded.emit(this.files);
   }
 }


### PR DESCRIPTION
FOM-46: adjust ngx-preview box height to be within container so that when hover we can see remove button for the upload.
FOM-46: fix error text overlapping with allowed file types text.
FOM-46: Fix fileupload error message issue when last file is removed.