### PR TITLE
Fix Add FOM picked commentingOpenDate timezone issue

### DIFF
--- a/apps/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/apps/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -218,7 +218,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
     let projectCreate = this.fg.value as ProjectCreateRequest
     projectCreate['districtId'] = this.districtIdSelect;
     projectCreate.forestClientNumber = this.fg.get('forestClient').value;
-
+    projectCreate.commentingOpenDate = moment(this.fg.get('commentingOpenDate').value).format('YYYY-MM-DD');
+    projectCreate.commentingClosedDate = moment(this.fg.get('commentingClosedDate').value).format('YYYY-MM-DD');
     this.projectSvc.projectControllerCreate(projectCreate)
         .toPromise()
         .then(result => this.onSuccess(result.id))
@@ -241,6 +242,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
 
     if (!this.fg.valid) return;
     try {
+      projectUpdateRequest.commentingOpenDate = moment(this.fg.get('commentingOpenDate').value).format('YYYY-MM-DD');
+      projectUpdateRequest.commentingClosedDate = moment(this.fg.get('commentingClosedDate').value).format('YYYY-MM-DD');
       await this.projectSvc.projectControllerUpdate(id, projectUpdateRequest).toPromise();
 
       let file: any = null;

--- a/apps/admin/src/app/foms/fom-submission/fom-submission.component.html
+++ b/apps/admin/src/app/foms/fom-submission/fom-submission.component.html
@@ -20,6 +20,7 @@
           (click)="submit()"
           [disabled]="!isSubmissionAllowed()"
         >{{ isLoading ? "Submitting" : "Submit" }}
+          <em class="spinner rotating" [hidden]="!isLoading"></em>
         </button>
       </div>
     </div>

--- a/apps/api/src/app/modules/project/project.service.ts
+++ b/apps/api/src/app/modules/project/project.service.ts
@@ -163,10 +163,6 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
   async create(request: any, user: User): Promise<ProjectResponse> {
     request.workflowStateCode = WorkflowStateEnum.INITIAL;
     request.forestClientId = request.forestClientNumber;
-    request.commentingOpenDate = request.commentingOpenDate? 
-            DateTimeUtil.getBcDate(request.commentingOpenDate).format(DateTimeUtil.DATE_FORMAT): null;
-    request.commentingClosedDate = request.commentingClosedDate? 
-            DateTimeUtil.getBcDate(request.commentingClosedDate).format(DateTimeUtil.DATE_FORMAT): null;
     return super.create(request, user);
   }
 

--- a/apps/api/src/core/dateTimeUtil.ts
+++ b/apps/api/src/core/dateTimeUtil.ts
@@ -32,7 +32,7 @@ export class DateTimeUtil {
 
     /**
      * 
-     * @param dateInput valid date input string for parsing.
+     * @param dateInput valid date input string (as "YYYY-MM-DD") for parsing.
      * @param timezone valid TimeZone string e.g 'America/Vancouver'.
      * @returns dayjs object based on 'timezone'.
      */
@@ -46,7 +46,7 @@ export class DateTimeUtil {
 
     /**
      * 
-     * @param dateInput valid date input string for parsing.
+     * @param dateInput valid date input string (as "YYYY-MM-DD") for parsing.
      * @returns dayjs object at BC timezone 'America/Vancouver'.
      */
     public static getBcDate(dateInput: string) {
@@ -55,8 +55,8 @@ export class DateTimeUtil {
 
     /**
      * 
-     * @param startDateSt beginning date as string.
-     * @param endDateSt end date as string.
+     * @param startDateSt beginning date as string (as "YYYY-MM-DD").
+     * @param endDateSt end date as string (as "YYYY-MM-DD").
      * @param timezone valid TimeZone string e.g 'America/Vancouver'.
      * @param unit dayjs valid unit.
      * @returns # of unit difference between two dates.


### PR DESCRIPTION
- Remove redundant date conversion when create.
- Format commentingOpenDate/commentingClosedDate to pass to backend
- Add 'rotating' for button when loading in submission.