### PR TITLE
FOM-109

### DIFF
--- a/apps/admin/src/core/interceptors/http-error.interceptor.ts
+++ b/apps/admin/src/core/interceptors/http-error.interceptor.ts
@@ -26,6 +26,8 @@ export class ErrorInterceptor implements HttpInterceptor {
           this.modalSvc.openErrorDialog(`The request was not valid: ${error} <br/>Please fix the issue and try again.`, 'Bad Request');
         } else if (statusCode == 403) { // Forbidden
           this.modalSvc.openErrorDialog(`You were not authorized to perform the request. Please try again. <br/>If this issue persists, try logging out and back in. If this still persists, please contact the service desk.`, 'Forbidden');
+        } else if (statusCode == 422) {
+          this.modalSvc.openErrorDialog(`The request was not valid: ${error}`, 'Bad Request');
         } else if (statusCode == 500) { // System Error
           console.error(`${request.urlWithParams} failed with error: ` + JSON.stringify(err));
           this.modalSvc.openErrorDialog(`A system error occurred. Please try again later. If the issue persists please contact the service desk.`, 'System Error');

--- a/apps/admin/src/core/interceptors/http-error.interceptor.ts
+++ b/apps/admin/src/core/interceptors/http-error.interceptor.ts
@@ -27,7 +27,7 @@ export class ErrorInterceptor implements HttpInterceptor {
         } else if (statusCode == 403) { // Forbidden
           this.modalSvc.openErrorDialog(`You were not authorized to perform the request. Please try again. <br/>If this issue persists, try logging out and back in. If this still persists, please contact the service desk.`, 'Forbidden');
         } else if (statusCode == 422) {
-          this.modalSvc.openErrorDialog(`The request was not valid: ${error}`, 'Bad Request');
+          this.modalSvc.openErrorDialog(` ${error}`, 'Save Conflict');
         } else if (statusCode == 500) { // System Error
           console.error(`${request.urlWithParams} failed with error: ` + JSON.stringify(err));
           this.modalSvc.openErrorDialog(`A system error occurred. Please try again later. If the issue persists please contact the service desk.`, 'System Error');

--- a/apps/api/src/app/modules/project/project.service.ts
+++ b/apps/api/src/app/modules/project/project.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { getRepository, Repository, SelectQueryBuilder } from 'typeorm';
 import * as dayjs from 'dayjs';
@@ -313,7 +313,7 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
 
     if (entity.revisionCount != request.revisionCount) {
       this.logger.debug("Entity revision count " + entity.revisionCount + " dto revision count = " + request.revisionCount);
-      throw new BadRequestException("Entity has been modified since you retrieved it for editing. Please reload and try again.");
+      throw new UnprocessableEntityException("The record you are trying to save has been changed since you retrieved it for editing. Please refresh and try again.");
     }
 
     if (request.workflowStateCode == entity.workflowStateCode) {
@@ -402,7 +402,7 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
 
     if (entity.revisionCount != request.revisionCount) {
       this.logger.debug("Entity revision count " + entity.revisionCount + " dto revision count = " + request.revisionCount);
-      throw new BadRequestException("Entity has been modified since you retrieved it for editing. Please reload and try again.");
+      throw new UnprocessableEntityException("The record you are trying to save has been changed since you retrieved it for editing. Please refresh and try again.");
     }
     if (isNil(request.commentClassificationMandatory)) {
       throw new BadRequestException("Must provide a value for requested field to change.");
@@ -625,7 +625,7 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
     }
 
     if (entity.revisionCount != request.revisionCount) {
-      throw new BadRequestException("Entity has been modified since you retrieved it for editing. Please reload and try again.");
+      throw new UnprocessableEntityException("The record you are trying to save has been changed since you retrieved it for editing. Please refresh and try again.");
     }
 
     if (isNil(request.commentingClosedDate || !dayjs(request.commentingClosedDate, this.DATE_FORMAT).isValid())) {

--- a/apps/api/src/core/models/data.service.ts
+++ b/apps/api/src/core/models/data.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
 import { PinoLogger } from 'nestjs-pino';
 import { Repository, UpdateResult } from 'typeorm';
 import { FindManyOptions } from 'typeorm/find-options/FindManyOptions';
@@ -162,7 +162,7 @@ export abstract class DataService<
     }
     if (entity.revisionCount != requestDto.revisionCount) {
       this.logger.debug("Entity revision count " + entity.revisionCount + " dto revision count = " + requestDto.revisionCount);
-      throw new BadRequestException("Entity has been modified since you retrieved it for editing. Please reload and try again.");
+      throw new UnprocessableEntityException("The record you are trying to save has been changed since you retrieved it for editing. Please refresh and try again.");
     }
     requestDto.revisionCount += 1;
 


### PR DESCRIPTION
- Use UnprocessableEntityException instead of BadRequestException for saving entity change error.
- Add new http statusCode 422 condition and revised for a better user error message.